### PR TITLE
fix: harden foundational runtime coordination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,8 @@ name = "gnosis-config"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "fs2",
+ "libc",
  "serde",
  "tempfile",
  "toml",

--- a/crates/gnosis-config/Cargo.toml
+++ b/crates/gnosis-config/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+fs2.workspace = true
+libc.workspace = true
 serde.workspace = true
 toml.workspace = true
 uuid.workspace = true

--- a/crates/gnosis-config/src/lib.rs
+++ b/crates/gnosis-config/src/lib.rs
@@ -1,11 +1,14 @@
 use std::{
     collections::BTreeMap,
-    fs,
+    fs::{self, File, OpenOptions},
+    io::Write,
     net::Ipv4Addr,
+    os::unix::fs::{OpenOptionsExt, PermissionsExt},
     path::{Component, Path, PathBuf},
 };
 
 use anyhow::{Context, Result, bail, ensure};
+use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -199,8 +202,14 @@ impl Config {
     /// Returns an error when the source configuration is invalid or the
     /// persistent TOML rewrite cannot be committed.
     pub fn load_persistent(path: &Path) -> Result<Self> {
+        let _lock = lock_config(path)?;
         let config = Self::load(path)?;
         if config.container.uuid.is_none() {
+            let mode = fs::metadata(path)
+                .with_context(|| format!("failed to read config metadata {}", path.display()))?
+                .permissions()
+                .mode()
+                & 0o777;
             let source = fs::read_to_string(path)
                 .with_context(|| format!("failed to read config {}", path.display()))?;
             let mut document: toml::Value = toml::from_str(&source)
@@ -216,12 +225,31 @@ impl Config {
             let encoded = toml::to_string_pretty(&document)
                 .context("failed to serialize persistent TOML config")?;
             let temporary = path.with_extension(format!("{}.tmp", Uuid::new_v4()));
-            fs::write(&temporary, encoded).with_context(|| {
-                format!("failed to write temporary config {}", temporary.display())
-            })?;
-            fs::rename(&temporary, path).with_context(|| {
-                format!("failed to commit persistent config {}", path.display())
-            })?;
+            let result = (|| {
+                let mut file = OpenOptions::new()
+                    .write(true)
+                    .create_new(true)
+                    .mode(mode)
+                    .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+                    .open(&temporary)
+                    .with_context(|| {
+                        format!("failed to create temporary config {}", temporary.display())
+                    })?;
+                file.set_permissions(fs::Permissions::from_mode(mode))?;
+                file.write_all(encoded.as_bytes()).with_context(|| {
+                    format!("failed to write temporary config {}", temporary.display())
+                })?;
+                file.sync_all()?;
+                fs::rename(&temporary, path).with_context(|| {
+                    format!("failed to commit persistent config {}", path.display())
+                })?;
+                File::open(parent_directory(path))?.sync_all()?;
+                Ok::<(), anyhow::Error>(())
+            })();
+            if result.is_err() {
+                fs::remove_file(&temporary).ok();
+            }
+            result?;
             return Self::load(path);
         }
         Ok(config)
@@ -418,6 +446,33 @@ impl Config {
     }
 }
 
+fn lock_config(path: &Path) -> Result<File> {
+    let mut name = path
+        .file_name()
+        .context("config path has no filename")?
+        .to_os_string();
+    name.push(".lock");
+    let lock_path = path.with_file_name(name);
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .mode(0o600)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(&lock_path)
+        .with_context(|| format!("failed to open config lock {}", lock_path.display()))?;
+    file.lock_exclusive()
+        .with_context(|| format!("failed to lock config {}", path.display()))?;
+    Ok(file)
+}
+
+fn parent_directory(path: &Path) -> &Path {
+    path.parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+}
+
 fn parse_environment_file(path: &Path) -> Result<BTreeMap<String, String>> {
     let source = fs::read_to_string(path)
         .with_context(|| format!("failed to read environment file {}", path.display()))?;
@@ -525,7 +580,12 @@ fn valid_interface_name(name: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
+    use std::{
+        fs,
+        os::unix::fs::PermissionsExt,
+        sync::{Arc, Barrier},
+        thread,
+    };
 
     use tempfile::tempdir;
 
@@ -570,7 +630,91 @@ mod tests {
         let second = Config::load_persistent(&path).unwrap();
         assert_eq!(first.container.uuid, second.container.uuid);
         assert!(first.container.uuid.is_some());
-        assert_eq!(fs::read_dir(dir.path()).unwrap().count(), 2);
+        assert!(fs::read_dir(dir.path()).unwrap().all(|entry| {
+            !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .ends_with(".tmp")
+        }));
+    }
+
+    #[test]
+    fn persists_restrictive_permissions() {
+        let dir = tempdir().unwrap();
+        fs::create_dir_all(dir.path().join("rootfs/sbin")).unwrap();
+        fs::write(dir.path().join("rootfs/sbin/init"), "").unwrap();
+        let path = dir.path().join("container.toml");
+        fs::write(
+            &path,
+            "[runtime]\nworkdir = 'state'\n\n[container]\nname = 'test'\nrootfs = 'rootfs'\n",
+        )
+        .unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+
+        Config::load_persistent(&path).unwrap();
+
+        let mode = fs::metadata(path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+
+    #[test]
+    fn does_not_copy_special_permission_bits() {
+        let dir = tempdir().unwrap();
+        fs::create_dir_all(dir.path().join("rootfs/sbin")).unwrap();
+        fs::write(dir.path().join("rootfs/sbin/init"), "").unwrap();
+        let path = dir.path().join("container.toml");
+        fs::write(
+            &path,
+            "[runtime]\nworkdir = 'state'\n\n[container]\nname = 'test'\nrootfs = 'rootfs'\n",
+        )
+        .unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o7600)).unwrap();
+
+        Config::load_persistent(&path).unwrap();
+
+        let mode = fs::metadata(path).unwrap().permissions().mode() & 0o7777;
+        assert_eq!(mode, 0o600);
+    }
+
+    #[test]
+    fn bare_config_filename_uses_current_directory() {
+        assert_eq!(
+            parent_directory(Path::new("container.toml")),
+            Path::new(".")
+        );
+    }
+
+    #[test]
+    fn concurrent_persistent_loads_share_uuid() {
+        const CALLERS: usize = 32;
+
+        let dir = tempdir().unwrap();
+        fs::create_dir_all(dir.path().join("rootfs/sbin")).unwrap();
+        fs::write(dir.path().join("rootfs/sbin/init"), "").unwrap();
+        let path = dir.path().join("container.toml");
+        fs::write(
+            &path,
+            "[runtime]\nworkdir = 'state'\n\n[container]\nname = 'test'\nrootfs = 'rootfs'\n",
+        )
+        .unwrap();
+        let barrier = Arc::new(Barrier::new(CALLERS));
+        let callers = (0..CALLERS)
+            .map(|_| {
+                let path = path.clone();
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    Config::load_persistent(&path).unwrap().container.uuid
+                })
+            })
+            .collect::<Vec<_>>();
+        let uuids = callers
+            .into_iter()
+            .map(|caller| caller.join().unwrap())
+            .collect::<Vec<_>>();
+
+        assert!(uuids.iter().all(|uuid| *uuid == uuids[0]));
     }
 
     #[test]

--- a/crates/gnosis-runtime/src/host/cgroup.rs
+++ b/crates/gnosis-runtime/src/host/cgroup.rs
@@ -5,13 +5,19 @@ use std::{
 
 use anyhow::{Context, Result, ensure};
 use gnosis_config::ResourceConfig;
+use uuid::Uuid;
 
 pub struct Cgroup {
     path: Option<PathBuf>,
 }
 
 impl Cgroup {
-    pub fn create(workdir: &Path, name: &str, resources: &ResourceConfig) -> Result<Self> {
+    pub fn create(
+        workdir: &Path,
+        name: &str,
+        uuid: Uuid,
+        resources: &ResourceConfig,
+    ) -> Result<Self> {
         if resources.memory_bytes.is_none()
             && resources.cpu_quota.is_none()
             && resources.pids.is_none()
@@ -23,7 +29,7 @@ impl Cgroup {
             root.join("cgroup.controllers").exists(),
             "resource limits require cgroup v2"
         );
-        let path = root.join("gnosis").join(name);
+        let path = root.join("gnosis").join(cgroup_name(name, uuid));
         fs::create_dir_all(&path)
             .with_context(|| format!("failed to create cgroup {}", path.display()))?;
         if let Some(memory) = resources.memory_bytes {
@@ -60,8 +66,28 @@ impl Cgroup {
     }
 }
 
+fn cgroup_name(name: &str, uuid: Uuid) -> String {
+    format!("{name}-{uuid}")
+}
+
 impl Drop for Cgroup {
     fn drop(&mut self) {
         let _ = self.remove();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    #[test]
+    fn same_named_configs_have_distinct_cgroups() {
+        let first = cgroup_name("same", Uuid::nil());
+        let second = cgroup_name("same", Uuid::max());
+
+        assert_ne!(first, second);
+        assert!(first.starts_with("same-"));
+        assert!(second.starts_with("same-"));
     }
 }

--- a/crates/gnosis-runtime/src/host/network.rs
+++ b/crates/gnosis-runtime/src/host/network.rs
@@ -2,7 +2,7 @@ use std::{
     fmt::Write as _,
     fs::{self, File, OpenOptions},
     os::{fd::AsFd, unix::fs::OpenOptionsExt},
-    path::Path,
+    path::{Path, PathBuf},
     process::Command,
 };
 
@@ -12,11 +12,15 @@ use gnosis_config::{Config, NetworkMode, Protocol};
 use nix::sched::{CloneFlags, setns};
 use serde::{Deserialize, Serialize};
 
+use crate::runtime::state::ensure_trusted_directory;
+
+const NETWORK_RUNTIME_DIRECTORY: &str = "/run/gnosis";
+
 pub struct Network {
     host_link: Option<String>,
     peer_link: Option<String>,
     rules: Vec<Vec<String>>,
-    workdir: Option<std::path::PathBuf>,
+    managed: bool,
     nat_lease: bool,
 }
 
@@ -33,8 +37,8 @@ impl Network {
             return Ok(network);
         }
 
-        let _lock = network_lock(&config.runtime.workdir)?;
-        network.workdir = Some(config.runtime.workdir.clone());
+        let _lock = network_lock()?;
+        network.managed = true;
         let host_link = format!("dsv{init_pid}");
         let peer_link = format!("dsp{init_pid}");
         network.host_link = Some(host_link.clone());
@@ -69,7 +73,7 @@ impl Network {
             )?;
 
             if config.container.network == NetworkMode::Nat {
-                acquire_nat_lease(&config.runtime.workdir)?;
+                acquire_nat_lease()?;
                 network.nat_lease = true;
                 fs::write("/proc/sys/net/ipv4/ip_forward", "1")?;
                 let subnet = format!(
@@ -225,7 +229,7 @@ impl Network {
             host_link: None,
             peer_link: None,
             rules: Vec::new(),
-            workdir: None,
+            managed: false,
             nat_lease: false,
         }
     }
@@ -239,10 +243,7 @@ impl Network {
     }
 
     fn cleanup_resources(&mut self) {
-        let _lock = self
-            .workdir
-            .as_deref()
-            .and_then(|workdir| network_lock(workdir).ok());
+        let _lock = self.managed.then(|| network_lock().ok()).flatten();
         self.cleanup_resources_locked();
     }
 
@@ -260,12 +261,10 @@ impl Network {
         }
         self.peer_link = None;
         if self.nat_lease {
-            if let Some(workdir) = &self.workdir {
-                let _ = release_nat_lease(workdir);
-            }
+            let _ = release_nat_lease();
             self.nat_lease = false;
         }
-        self.workdir = None;
+        self.managed = false;
     }
 }
 
@@ -275,8 +274,9 @@ impl Drop for Network {
     }
 }
 
-fn network_lock(workdir: &Path) -> Result<File> {
-    fs::create_dir_all(workdir)?;
+fn network_lock() -> Result<File> {
+    let directory = Path::new(NETWORK_RUNTIME_DIRECTORY);
+    ensure_trusted_directory(directory)?;
     let file = OpenOptions::new()
         .read(true)
         .write(true)
@@ -284,7 +284,7 @@ fn network_lock(workdir: &Path) -> Result<File> {
         .truncate(false)
         .mode(0o600)
         .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
-        .open(workdir.join("network.lock"))?;
+        .open(directory.join("network.lock"))?;
     file.lock_exclusive()?;
     Ok(file)
 }
@@ -295,8 +295,8 @@ struct NatLease {
     restore_disabled: bool,
 }
 
-fn acquire_nat_lease(workdir: &Path) -> Result<()> {
-    let path = workdir.join("network-state.json");
+fn acquire_nat_lease() -> Result<()> {
+    let path = nat_lease_path();
     let mut lease = read_nat_lease(&path);
     if lease.users == 0 {
         lease.restore_disabled = fs::read_to_string("/proc/sys/net/ipv4/ip_forward")?.trim() == "0";
@@ -305,8 +305,8 @@ fn acquire_nat_lease(workdir: &Path) -> Result<()> {
     write_nat_lease(&path, &lease)
 }
 
-fn release_nat_lease(workdir: &Path) -> Result<()> {
-    let path = workdir.join("network-state.json");
+fn release_nat_lease() -> Result<()> {
+    let path = nat_lease_path();
     let mut lease = read_nat_lease(&path);
     lease.users = lease.users.saturating_sub(1);
     if lease.users == 0 {
@@ -335,6 +335,10 @@ fn write_nat_lease(path: &Path, lease: &NatLease) -> Result<()> {
     fs::write(&temporary, serde_json::to_vec(lease)?)?;
     fs::rename(temporary, path)?;
     Ok(())
+}
+
+fn nat_lease_path() -> PathBuf {
+    Path::new(NETWORK_RUNTIME_DIRECTORY).join("network-state.json")
 }
 
 fn owned_rule(name: &str, pid: i32, rule: &[&str]) -> Vec<String> {
@@ -441,4 +445,17 @@ fn masked_network(address: std::net::Ipv4Addr, prefix: u8) -> std::net::Ipv4Addr
         u32::MAX << (32 - prefix)
     };
     std::net::Ipv4Addr::from(u32::from(address) & mask)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nat_lease_uses_global_runtime_directory() {
+        assert_eq!(
+            nat_lease_path(),
+            Path::new("/run/gnosis/network-state.json")
+        );
+    }
 }

--- a/crates/gnosis-runtime/src/runtime/execute.rs
+++ b/crates/gnosis-runtime/src/runtime/execute.rs
@@ -111,6 +111,7 @@ impl Runtime {
                 let cgroup = Cgroup::create(
                     &self.config.runtime.workdir,
                     &self.config.container.name,
+                    state.uuid,
                     &self.config.container.resources,
                 )
                 .unwrap_or_else(|error| exec_failure(&error.to_string()));

--- a/crates/gnosis-runtime/src/runtime/lifecycle.rs
+++ b/crates/gnosis-runtime/src/runtime/lifecycle.rs
@@ -117,12 +117,13 @@ impl Runtime {
             .context("failed to create UTS/IPC namespaces")?;
         let rootfs = Rootfs::prepare(&self.config)?;
         let init_system = init::detect(rootfs.path(), &self.config.container.init);
+        let uuid = self.config.container.uuid.unwrap_or_else(Uuid::new_v4);
         let mut cgroup = Cgroup::create(
             &self.config.runtime.workdir,
             &self.config.container.name,
+            uuid,
             &self.config.container.resources,
         )?;
-        let uuid = self.config.container.uuid.unwrap_or_else(Uuid::new_v4);
         let host_boot_id = host_boot_id()?;
         let monitor_pid = getpid().as_raw();
         let monitor_start_time = process_start_time(monitor_pid)?;

--- a/crates/gnosis-runtime/src/runtime/state.rs
+++ b/crates/gnosis-runtime/src/runtime/state.rs
@@ -454,7 +454,7 @@ fn namespace_pid(pid: i32) -> Result<Option<i32>> {
     }))
 }
 
-fn ensure_trusted_directory(path: &Path) -> Result<()> {
+pub(crate) fn ensure_trusted_directory(path: &Path) -> Result<()> {
     use std::os::unix::fs::{MetadataExt, PermissionsExt};
     if !path.exists() {
         fs::create_dir_all(path)?;


### PR DESCRIPTION
## Warning

> **Foundational fix only:** this change has not been validated in a real privileged runtime environment. It should not be treated as production-proven until the scenarios below are exercised on a compatible Linux host.

## Summary

- serialize persistent config UUID generation and preserve restrictive file permissions
- coordinate NAT forwarding leases globally across runtime work directories
- isolate same-named container cgroups with the active configuration UUID
- cover concurrent config loading, permission handling, global NAT paths, and cgroup naming with unit tests

## Automated validation

- `cargo test --workspace -- --skip parses_namespace_and_parent_pids`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

The skipped procfs test depends on PID namespace information unavailable in the current environment.

## Not yet tested in practice

- privileged container start, stop, reboot, enter, and run workflows
- real `net.ipv4.ip_forward` and iptables behavior across multiple work directories
- real cgroup v2 creation, attachment, resource enforcement, and cleanup
- crash recovery while NAT leases or cgroups are active

## Out of scope

- stable `/proc` handles and PID-reuse hardening for execute/enter remain deferred